### PR TITLE
[Feature] Add home page, navbar, and notifier to the app

### DIFF
--- a/lib/data/classes/notifiers.dart
+++ b/lib/data/classes/notifiers.dart
@@ -1,0 +1,3 @@
+import 'package:flutter/material.dart';
+
+ValueNotifier<int> selectedPageNotifier = ValueNotifier(0);

--- a/lib/views/pages/home.dart
+++ b/lib/views/pages/home.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({super.key});
+  const HomePage({
+    super.key,
+    required this.appBarTitle,
+    required this.appBarColor,
+  });
+  final String appBarTitle;
+  final Color appBarColor;
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -10,12 +16,6 @@ class HomePage extends StatefulWidget {
 class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text("Home page"),
-        backgroundColor: Color(0xFF086788),
-      ),
-      body: Text("Hey"),
-    );
+    return Scaffold(body: Center(child: Text("You are on the home page")));
   }
 }

--- a/lib/views/pages/home.dart
+++ b/lib/views/pages/home.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Home page"),
+        backgroundColor: Color(0xFF086788),
+      ),
+      body: Text("Hey"),
+    );
+  }
+}

--- a/lib/views/pages/sign_up.dart
+++ b/lib/views/pages/sign_up.dart
@@ -1,4 +1,4 @@
-import 'package:ecg_app/views/pages/home.dart';
+import 'package:ecg_app/views/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
 
 class SignUpPage extends StatefulWidget {
@@ -21,11 +21,11 @@ class _SignUpPageState extends State<SignUpPage> {
           Text("Hi you are in the sign up page"),
           Center(
             child: FilledButton(
-              onPressed: () => Navigator.push(
+              onPressed: () => Navigator.pushReplacement(
                 context,
                 MaterialPageRoute(
                   builder: (context) {
-                    return HomePage();
+                    return WidgetTree();
                   },
                 ),
               ),

--- a/lib/views/pages/sign_up.dart
+++ b/lib/views/pages/sign_up.dart
@@ -1,3 +1,4 @@
+import 'package:ecg_app/views/pages/home.dart';
 import 'package:flutter/material.dart';
 
 class SignUpPage extends StatefulWidget {
@@ -15,7 +16,24 @@ class _SignUpPageState extends State<SignUpPage> {
         title: Text("Sign up", selectionColor: Color(0xFF1D1B14)),
         backgroundColor: Color(0xFF07A0C3),
       ),
-      body: Center(child: Text("Hi you are in the sign up page")),
+      body: Column(
+        children: [
+          Text("Hi you are in the sign up page"),
+          Center(
+            child: FilledButton(
+              onPressed: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) {
+                    return HomePage();
+                  },
+                ),
+              ),
+              child: Text("Go to home"),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/views/widgets/navbar_widget.dart
+++ b/lib/views/widgets/navbar_widget.dart
@@ -1,0 +1,28 @@
+import 'package:ecg_app/data/classes/notifiers.dart';
+import 'package:flutter/material.dart';
+
+class NavbarWidget extends StatelessWidget {
+  const NavbarWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: selectedPageNotifier,
+      builder: (context, selectedPage, child) {
+        return NavigationBar(
+          destinations: [
+            NavigationDestination(icon: Icon(Icons.home), label: "Home"),
+            NavigationDestination(
+              icon: Icon(Icons.person),
+              label: "Profile page",
+            ),
+          ],
+          onDestinationSelected: (int value) {
+            selectedPageNotifier.value = value;
+          },
+          selectedIndex: selectedPage,
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/widget_tree.dart
+++ b/lib/views/widgets/widget_tree.dart
@@ -1,0 +1,58 @@
+import 'package:ecg_app/data/classes/notifiers.dart';
+import 'package:ecg_app/views/pages/home.dart';
+import 'package:ecg_app/views/widgets/navbar_widget.dart';
+import 'package:flutter/material.dart';
+
+// Defines params for navbarPages within navbar
+// without it, we would need to create a new navbar + buttons
+class PageConfig {
+  final String title;
+  final Color color;
+  final Widget page;
+  const PageConfig({
+    required this.title,
+    required this.color,
+    required this.page,
+  });
+}
+
+final List<PageConfig> navbarPages = [
+  PageConfig(
+    title: "Home page",
+    color: const Color(0xFF086788),
+    page: HomePage(appBarTitle: "Home page", appBarColor: Color(0xFF086788)),
+  ),
+  PageConfig(
+    title: "Profile page",
+    color: Colors.green,
+    page: const Center(child: Text("Profile page")),
+  ),
+];
+
+class WidgetTree extends StatelessWidget {
+  const WidgetTree({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<int>(
+      valueListenable: selectedPageNotifier,
+      builder: (context, selectedPage, child) {
+        final config = navbarPages[selectedPage];
+
+        return Scaffold(
+          appBar: AppBar(
+            title: Text(config.title),
+            backgroundColor: config.color,
+            centerTitle: true,
+            actions: [
+              IconButton(onPressed: () {}, icon: const Icon(Icons.settings)),
+              IconButton(onPressed: () {}, icon: const Icon(Icons.dark_mode)),
+            ],
+          ),
+          body: config.page,
+          bottomNavigationBar: const NavbarWidget(),
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/widget_tree.dart
+++ b/lib/views/widgets/widget_tree.dart
@@ -29,6 +29,9 @@ final List<PageConfig> navbarPages = [
   ),
 ];
 
+// This widget is what handles the navbar logic after logging in
+// without the need of rebuilding the appbar.
+// tl;dr builds the appbar and the navbar thats shared between pages
 class WidgetTree extends StatelessWidget {
   const WidgetTree({super.key});
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,23 +8,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_ecg_app/main.dart';
+import 'package:ecg_app/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verifies that the app comes up without crashing
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
Initially wanted to just add the home page, ended up adding more
## Here's the list of changes
- Added `home.dart` which the user enters after login
- Added `navbar.dart` widget which adds a navbar for easy navigation
- Added `/data/classes/notifier.dart` to allow our `widget_tree.dart` to update the page without creating new Scaffold
- Added `widgets/widget_tree.dart` to handle the logic of displaying the navbar and associated functions
- Updated `widget_test.dart` to use the proper `main.dart` location, and changed the validation to check if the app is running without crashing