### PR TITLE
[Feature] Add dark mode functionality + streamline navbar widget

### DIFF
--- a/lib/data/classes/constants.dart
+++ b/lib/data/classes/constants.dart
@@ -1,0 +1,3 @@
+class KConstants {
+  static const String brightnessKey = 'brightnessKey';
+}

--- a/lib/data/classes/notifiers.dart
+++ b/lib/data/classes/notifiers.dart
@@ -1,3 +1,4 @@
 import 'package:flutter/material.dart';
 
+ValueNotifier<bool> isDarkModeNotifier = ValueNotifier(true);
 ValueNotifier<int> selectedPageNotifier = ValueNotifier(0);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:ecg_app/data/classes/notifiers.dart';
 import 'package:flutter/material.dart';
 import 'package:ecg_app/views/pages/sign_up.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 void main() {
   runApp(const MyApp());
@@ -16,7 +18,15 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   @override
   void initState() {
+    initBrightnessTheme();
     super.initState();
+  }
+
+  // Used to read the KV stored in phone's memory to get brightness pref
+  void initBrightnessTheme() async {
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    final bool? savedThemeIsDark = prefs.getBool(KConstants.brightnessKey);
+    isDarkModeNotifier.value = savedThemeIsDark ?? false;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:ecg_app/data/classes/notifiers.dart';
 import 'package:flutter/material.dart';
 import 'package:ecg_app/views/pages/sign_up.dart';
 
@@ -20,14 +21,22 @@ class _MyAppState extends State<MyApp> {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'ECG app',
-      // Removes the ugly debug banner
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Color(0xFF086788)),
-      ),
-      home: SignUpPage(),
+    return ValueListenableBuilder(
+      valueListenable: isDarkModeNotifier,
+      builder: (context, isDarkMode, child) {
+        return MaterialApp(
+          title: 'ECG app',
+          // Removes the ugly debug banner
+          debugShowCheckedModeBanner: false,
+          theme: ThemeData(
+            colorScheme: ColorScheme.fromSeed(
+              seedColor: Color(0xFF086788),
+              brightness: isDarkMode ? Brightness.dark : Brightness.light,
+            ),
+          ),
+          home: SignUpPage(),
+        );
+      },
     );
   }
 }

--- a/lib/views/widgets/navbar_widget.dart
+++ b/lib/views/widgets/navbar_widget.dart
@@ -1,28 +1,24 @@
-import 'package:ecg_app/data/classes/notifiers.dart';
+import 'package:ecg_app/views/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
 
 class NavbarWidget extends StatelessWidget {
-  const NavbarWidget({super.key});
-
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+  const NavbarWidget({
+    super.key,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+  });
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder(
-      valueListenable: selectedPageNotifier,
-      builder: (context, selectedPage, child) {
-        return NavigationBar(
-          destinations: [
-            NavigationDestination(icon: Icon(Icons.home), label: "Home"),
-            NavigationDestination(
-              icon: Icon(Icons.person),
-              label: "Profile page",
-            ),
-          ],
-          onDestinationSelected: (int value) {
-            selectedPageNotifier.value = value;
-          },
-          selectedIndex: selectedPage,
-        );
-      },
+    return NavigationBar(
+      destinations: [
+        for (var page in navbarPages)
+          NavigationDestination(icon: Icon(page.icon), label: page.title),
+      ],
+
+      selectedIndex: selectedIndex,
+      onDestinationSelected: onDestinationSelected,
     );
   }
 }

--- a/lib/views/widgets/widget_tree.dart
+++ b/lib/views/widgets/widget_tree.dart
@@ -1,7 +1,9 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:ecg_app/data/classes/notifiers.dart';
 import 'package:ecg_app/views/pages/home.dart';
 import 'package:ecg_app/views/widgets/navbar_widget.dart';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 // Defines params for navbarPages within navbar
 // without it, we would need to create a new navbar + buttons
@@ -60,10 +62,23 @@ class WidgetTree extends StatelessWidget {
             actions: [
               IconButton(onPressed: () {}, icon: const Icon(Icons.settings)),
               IconButton(
-                onPressed: () {
+                onPressed: () async {
+                  final SharedPreferences prefs =
+                      await SharedPreferences.getInstance();
+                  await prefs.setBool(
+                    KConstants.brightnessKey,
+                    !isDarkModeNotifier.value,
+                  );
                   isDarkModeNotifier.value = !isDarkModeNotifier.value;
                 },
-                icon: const Icon(Icons.dark_mode),
+                icon: ValueListenableBuilder(
+                  valueListenable: isDarkModeNotifier,
+                  builder: (context, isDarkMode, child) {
+                    return Icon(
+                      isDarkMode ? Icons.dark_mode : Icons.light_mode,
+                    );
+                  },
+                ),
               ),
             ],
           ),

--- a/lib/views/widgets/widget_tree.dart
+++ b/lib/views/widgets/widget_tree.dart
@@ -9,10 +9,15 @@ class PageConfig {
   final String title;
   final Color color;
   final Widget page;
+  final IconData icon;
+  final Text label;
+
   const PageConfig({
     required this.title,
     required this.color,
     required this.page,
+    required this.icon,
+    required this.label,
   });
 }
 
@@ -21,11 +26,16 @@ final List<PageConfig> navbarPages = [
     title: "Home page",
     color: const Color(0xFF086788),
     page: HomePage(appBarTitle: "Home page", appBarColor: Color(0xFF086788)),
+    icon: Icons.home,
+    label: Text("Home page"),
   ),
+
   PageConfig(
     title: "Profile page",
     color: Colors.green,
     page: const Center(child: Text("Profile page")),
+    icon: Icons.person,
+    label: Text("Profile page"),
   ),
 ];
 
@@ -49,11 +59,20 @@ class WidgetTree extends StatelessWidget {
             centerTitle: true,
             actions: [
               IconButton(onPressed: () {}, icon: const Icon(Icons.settings)),
-              IconButton(onPressed: () {}, icon: const Icon(Icons.dark_mode)),
+              IconButton(
+                onPressed: () {
+                  isDarkModeNotifier.value = !isDarkModeNotifier.value;
+                },
+                icon: const Icon(Icons.dark_mode),
+              ),
             ],
           ),
           body: config.page,
-          bottomNavigationBar: const NavbarWidget(),
+          bottomNavigationBar: NavbarWidget(
+            selectedIndex: selectedPage,
+            onDestinationSelected: (newSelectedPage) =>
+                selectedPageNotifier.value = newSelectedPage,
+          ),
         );
       },
     );

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -72,6 +88,11 @@ packages:
     version: "5.0.0"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -139,6 +160,102 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.11"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -208,6 +325,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Pretty simple commit

## Changes
- Utilized [Shared Preferences](https://pub.dev/packages/shared_preferences) to save `brightnessKey` to the mobile device as persistent storage.
- Reads and updates the KV value (`brightnessKey`) upon changing the lighting mode of the app by tapping the associated button on the home area.
- Removed duplicated login in `navbar_widget.dart` which would have required updating both `widget_tree.dart` and `navbar_widget.dart` if a change was needed.

Here's a video of the persistent dark mode setting working. It going back to the sign up page is the app restarting using Flutter's hot restart functionality. So it works!

https://github.com/user-attachments/assets/c16e289c-dac8-457e-a10f-eaafd19f5638

