### PR TITLE
[Bug fix + Feature] Introduced `BleEcgManager` to manage connection

### DIFF
--- a/lib/data/classes/ecg_packet.dart
+++ b/lib/data/classes/ecg_packet.dart
@@ -1,0 +1,27 @@
+import 'dart:typed_data';
+
+class EcgPacket {
+  final List<int> samples; // 10 samples
+  final int timestamp; // 4-byte timestamp
+
+  EcgPacket(this.samples, this.timestamp);
+
+  static EcgPacket? fromBytes(List<int> value) {
+    if (value.length != 24) {
+      print("Unexpected packet size: ${value.length}");
+      return null;
+    }
+
+    final bytes = Uint8List.fromList(value);
+    final byteData = ByteData.sublistView(bytes);
+
+    final samples = List<int>.generate(
+      10,
+      (i) => byteData.getUint16(i * 2, Endian.little),
+    );
+
+    final timestamp = byteData.getUint32(20, Endian.little);
+    print(samples.toString());
+    return EcgPacket(samples, timestamp);
+  }
+}

--- a/lib/data/classes/ecg_packet.dart
+++ b/lib/data/classes/ecg_packet.dart
@@ -1,6 +1,8 @@
 import 'dart:typed_data';
 
 class EcgPacket {
+  // Currently is 24 bytes - 10 samples of 2 byte length
+  // and a 4 byte timestamp.
   final List<int> samples; // 10 samples
   final int timestamp; // 4-byte timestamp
 

--- a/lib/data/classes/ecg_packet.dart
+++ b/lib/data/classes/ecg_packet.dart
@@ -21,7 +21,6 @@ class EcgPacket {
     );
 
     final timestamp = byteData.getUint32(20, Endian.little);
-    print(samples.toString());
     return EcgPacket(samples, timestamp);
   }
 }

--- a/lib/views/pages/ble_scanner.dart
+++ b/lib/views/pages/ble_scanner.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:ecg_app/data/classes/notifiers.dart';
+import 'package:ecg_app/views/widgets/ble_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
@@ -119,7 +120,8 @@ class _BleScannerState extends State<BleScanner> {
       }
 
       print('Connecting to ${device.remoteId}');
-      await device.connect(timeout: const Duration(seconds: 10));
+      // USes the ECGManager
+      await BleEcgManager().connect(device);
       if (!mounted) {
         return;
       }

--- a/lib/views/pages/ble_scanner.dart
+++ b/lib/views/pages/ble_scanner.dart
@@ -120,17 +120,14 @@ class _BleScannerState extends State<BleScanner> {
       }
 
       print('Connecting to ${device.remoteId}');
-      // USes the ECGManager
+      // Uses BleEcgManager to manage the connection
       await BleEcgManager().connect(device);
       if (!mounted) {
         return;
       }
       print('Connected to ${device.remoteId}');
-      print('Notifier BEFORE: ${connectedDevice.value}');
-      connectedDevice.value = DeviceWrapper(
-        device,
-      ); // always a new wrapper object
-      print('Notifier AFTER: ${connectedDevice.value}');
+      // Used to circumvent ValueNotifier's same-object check
+      connectedDevice.value = DeviceWrapper(device);
 
       List<BluetoothService> services = await device.discoverServices();
       BluetoothCharacteristic? targetCharacteristic;

--- a/lib/views/pages/ecg_chart.dart
+++ b/lib/views/pages/ecg_chart.dart
@@ -1,233 +1,134 @@
 import 'dart:async';
-import 'dart:typed_data';
-
+import 'package:ecg_app/data/classes/ecg_packet.dart';
+import 'package:ecg_app/views/widgets/ble_manager.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 
 class EcgChart extends StatefulWidget {
-  final BluetoothDevice? ecgDevice;
-  const EcgChart({super.key, required this.ecgDevice});
+  const EcgChart({super.key});
+
   @override
   State<EcgChart> createState() => _EcgChartState();
 }
 
 class _EcgChartState extends State<EcgChart> {
-  BluetoothDevice? _connectedEcgDevice;
-  late ZoomPanBehavior _zoomPanBehavior;
-  StreamSubscription<List<int>>? _ecgSubscription;
+  // BLE manager instance: manages connection & provides stream of ECG packets
+  final BleEcgManager _bleManager = BleEcgManager();
 
-  // Chart-related
+  // Listener for EcgPackets
+  late StreamSubscription<EcgPacket> _ecgSub;
+
+  // Buffer for data when chart controller is not initialized.
+  final List<EcgPacket> _packetBuffer = [];
+
+  // Source of truth for our chart
   List<EcgDataPoint> ecgDataPoints = [];
-  double latestEcgTime = 0;
+
+  // Interacts with Syncfusion chart to update chart in real time
+  ChartSeriesController? _chartSeriesController;
+
   static const double fixedWindowSize = 2000.0;
-  late ChartSeriesController _chartSeriesController;
-  int? startTimestampMs;
-  final String serviceUuid = "b64cfb1e-045c-4975-89d6-65949bcb35aa";
-  final String characteristicUuid = "33737322-fb5c-4a6f-a4d9-e41c1b20c30d";
+  double latestEcgTime = 0;
+  int globalEcgMax = 4096;
+
   @override
   void initState() {
     super.initState();
-    _zoomPanBehavior = ZoomPanBehavior(enablePanning: true);
-    _connectedEcgDevice = widget.ecgDevice;
-    _resetData();
-    if (_connectedEcgDevice != null) {
-      _setupCharacteristic(_connectedEcgDevice!);
-    } else {
-      print("Sorry was null");
-    }
-  }
 
-  Future<void> _setupCharacteristic(BluetoothDevice device) async {
-    try {
-      List<BluetoothService> services = await device.discoverServices();
-      BluetoothCharacteristic? targetCharacteristic;
-
-      for (var service in services) {
-        if (service.uuid.str == serviceUuid) {
-          for (var c in service.characteristics) {
-            if (c.uuid.str == characteristicUuid) {
-              targetCharacteristic = c;
-              break;
-            }
-          }
-        }
-      }
-      // Converts the received bytes from the ble notification
-      // and sends it to be processed by handleNotificaiton
-      if (targetCharacteristic != null) {
-        await targetCharacteristic.setNotifyValue(true);
-        targetCharacteristic.onValueReceived.listen(
-          (value) => handleNotification(Uint8List.fromList(value)),
-        );
-      }
-
-      if (!mounted) {
-        return;
-      }
-
-      showDialog(
-        context: context,
-        builder: (_) => AlertDialog(
-          title: const Text('Connected'),
-          content: SizedBox(
-            width: 200.0,
-            height: 100.0,
-            child: Column(
-              children: [
-                Text('Successfully connected to ${device.platformName}'),
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      );
-    } catch (e) {
-      print('Connection failed: $e');
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Failed to connect to ${device.platformName}'),
-          ),
-        );
-      }
-    }
+    _ecgSub = _bleManager.ecgStream.listen((sample) {
+      _addPacket(sample);
+    });
   }
 
   @override
   void dispose() {
-    _ecgSubscription?.cancel();
-    _connectedEcgDevice?.disconnect();
+    _ecgSub.cancel();
     super.dispose();
   }
 
-  void _resetData() {
-    ecgDataPoints.clear();
-    startTimestampMs = null;
-    latestEcgTime = 0;
+  // Verifies controller iss initialized.
+  void _addPacket(EcgPacket packet) {
+    if (_chartSeriesController == null) {
+      _packetBuffer.add(packet);
+      return;
+    }
+    _processPacket(packet);
   }
 
-  void handleNotification(List<int> value) {
-    final packet = decodeEcgData(value);
-    if (packet == null) return;
+  // Generates timestamps for each sample in a packet and uploads the data to
+  // the chart
+  void _processPacket(EcgPacket packet) {
+    setState(() {
+      for (int i = 0; i < packet.samples.length; i++) {
+        final time = packet.timestamp + i * 4;
+        final value = globalEcgMax - packet.samples[i].toDouble();
 
-    startTimestampMs ??= packet.timestamp;
-    _updateChart(packet);
-  }
+        ecgDataPoints.add(EcgDataPoint(time.toDouble(), value));
+        // Update `latestEcgTime` to reflect most recent ecgTime value
+        latestEcgTime = time.toDouble();
+      }
 
-  void _updateChart(EcgPacket packet) {
-    for (int i = 0; i < packet.samples.length; i++) {
-      double ecgTime =
-          (packet.timestamp - (startTimestampMs ?? packet.timestamp))
-              .toDouble() +
-          i * 4;
-      double ecgValue = packet.samples[i].toDouble();
-
-      ecgDataPoints.add(EcgDataPoint(ecgTime, ecgValue));
-      latestEcgTime = ecgTime;
-
-      _chartSeriesController.updateDataSource(
-        addedDataIndexes: [ecgDataPoints.length - 1],
+      // Adds current ECG packet to the chart
+      _chartSeriesController?.updateDataSource(
+        addedDataIndexes: List.generate(
+          packet.samples.length,
+          (i) => ecgDataPoints.length - packet.samples.length + i,
+        ),
       );
-    }
 
-    double cutoff = ecgDataPoints.last.ecgTime - fixedWindowSize;
-    int removedCount = 0;
-    while (ecgDataPoints.isNotEmpty && ecgDataPoints.first.ecgTime < cutoff) {
-      ecgDataPoints.removeAt(0);
-      removedCount++;
-    }
+      // Defines the left-most data to be removed from the chart
+      double cutoff = ecgDataPoints.last.ecgTime - fixedWindowSize;
+      // Removes (removedCount) number of elements from the left.
+      int removedCount = ecgDataPoints.indexWhere((dp) => dp.ecgTime >= cutoff);
+      removedCount = removedCount == -1 ? 0 : removedCount;
 
-    if (removedCount > 0) {
-      _chartSeriesController.updateDataSource(
-        removedDataIndexes: List.generate(removedCount, (index) => index),
-      );
-    }
-
-    setState(() {});
+      if (removedCount > 0) {
+        ecgDataPoints.removeRange(0, removedCount);
+        _chartSeriesController?.updateDataSource(
+          removedDataIndexes: List.generate(removedCount, (i) => i),
+        );
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    // Define the visible window using absolute time on ecgTime axis:
     double maxX = latestEcgTime;
-    double minX = maxX - fixedWindowSize;
-    print("Hi I am from the ecg chart");
-    if (minX < 0) minX = 0;
-    return Scaffold(
-      body: _connectedEcgDevice == null
-          ? Text("Could not connect to ECG")
-          : Column(
-              children: [
-                Expanded(
-                  child: SfCartesianChart(
-                    backgroundColor: Colors.black,
-                    plotAreaBorderWidth: 0,
-                    primaryXAxis: NumericAxis(
-                      minimum: minX,
-                      maximum: maxX,
-                      interval:
-                          500, // Adds a tick mark every 500ms for clarity.
-                      edgeLabelPlacement: EdgeLabelPlacement.shift,
-                    ),
-                    primaryYAxis: NumericAxis(
-                      minimum: 0,
-                      maximum: 4096,
-                      interval: 512,
-                    ),
-                    series: [
-                      LineSeries<EcgDataPoint, double>(
-                        dataSource: ecgDataPoints,
-                        xValueMapper: (EcgDataPoint dp, _) => dp.ecgTime,
-                        yValueMapper: (EcgDataPoint dp, _) => dp.ecgValue,
-                        animationDuration: 0,
-                        // Absolutely necessary for real-time charting
-                        onRendererCreated: (controller) =>
-                            _chartSeriesController = controller,
-                        color: const Color.fromARGB(255, 228, 10, 10),
-                      ),
-                    ],
-                    zoomPanBehavior: _zoomPanBehavior,
-                  ),
-                ),
-              ],
-            ),
+    double minX = (maxX - fixedWindowSize).clamp(0, double.infinity);
+
+    return SfCartesianChart(
+      backgroundColor: Colors.black,
+      plotAreaBorderWidth: 0,
+      primaryXAxis: NumericAxis(minimum: minX, maximum: maxX, interval: 500),
+      primaryYAxis: NumericAxis(
+        minimum: 0,
+        maximum: globalEcgMax.toDouble(),
+        interval: 512,
+      ),
+      series: [
+        LineSeries<EcgDataPoint, double>(
+          dataSource: ecgDataPoints,
+          xValueMapper: (EcgDataPoint dp, _) => dp.ecgTime,
+          yValueMapper: (EcgDataPoint dp, _) => dp.ecgValue,
+          animationDuration: 0,
+          // Absolutely necessary for real-time charting
+          onRendererCreated: (controller) {
+            _chartSeriesController = controller;
+            // Flush buffered packets
+            for (final packet in _packetBuffer) {
+              _processPacket(packet);
+            }
+            _packetBuffer.clear();
+          },
+          color: const Color.fromARGB(255, 228, 10, 10),
+        ),
+      ],
     );
   }
-}
-
-// Keep your EcgPacket and EcgDataPoint classes as-is
-class EcgPacket {
-  final List<int> samples;
-  final int timestamp;
-  EcgPacket(this.samples, this.timestamp);
 }
 
 class EcgDataPoint {
   final double ecgTime;
   final double ecgValue;
   EcgDataPoint(this.ecgTime, this.ecgValue);
-}
-
-EcgPacket? decodeEcgData(List<int> value) {
-  if (value.length != 24) {
-    print("Unexpected packet size: ${value.length}");
-    return null;
-  }
-
-  final bytes = Uint8List.fromList(value);
-  final byteData = ByteData.sublistView(bytes);
-
-  List<int> samples = [];
-  for (int i = 0; i < 10; i++) {
-    samples.add(byteData.getUint16(i * 2, Endian.little));
-  }
-  int timestamp = byteData.getUint32(20, Endian.little);
-
-  return EcgPacket(samples, timestamp);
 }

--- a/lib/views/pages/ecg_page.dart
+++ b/lib/views/pages/ecg_page.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 class EcgPage extends StatefulWidget {
   final Color appBarColor;
   final String appBarTitle;
+
   const EcgPage({
     super.key,
     required this.appBarColor,
@@ -27,6 +28,7 @@ class _EcgPageState extends State<EcgPage> {
         print('ValueListenableBuilder builder called with $wrapper');
 
         if (wrapper == null) {
+          // not connected → show scanner
           return Scaffold(
             body: BleScanner(
               appBarColor: widget.appBarColor,
@@ -35,12 +37,8 @@ class _EcgPageState extends State<EcgPage> {
           );
         }
 
-        return Scaffold(
-          body: EcgChart(
-            key: ValueKey(wrapper.device),
-            ecgDevice: wrapper.device,
-          ),
-        );
+        // connected → just show the chart
+        return Scaffold(body: const EcgChart());
       },
     );
   }

--- a/lib/views/pages/ecg_page.dart
+++ b/lib/views/pages/ecg_page.dart
@@ -28,7 +28,6 @@ class _EcgPageState extends State<EcgPage> {
         print('ValueListenableBuilder builder called with $wrapper');
 
         if (wrapper == null) {
-          // not connected → show scanner
           return Scaffold(
             body: BleScanner(
               appBarColor: widget.appBarColor,
@@ -37,7 +36,6 @@ class _EcgPageState extends State<EcgPage> {
           );
         }
 
-        // connected → just show the chart
         return Scaffold(body: const EcgChart());
       },
     );

--- a/lib/views/widgets/ble_manager.dart
+++ b/lib/views/widgets/ble_manager.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:ecg_app/data/classes/ecg_packet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+
+class BleEcgManager extends ChangeNotifier {
+  static final BleEcgManager _instance = BleEcgManager._internal();
+  factory BleEcgManager() => _instance;
+  BleEcgManager._internal();
+
+  BluetoothDevice? _device;
+  StreamSubscription<List<int>>? _subscription;
+
+  final _ecgController = StreamController<EcgPacket>.broadcast();
+  Stream<EcgPacket> get ecgStream => _ecgController.stream;
+
+  bool _connected = false;
+  bool get isConnected => _connected;
+
+  // replace with your actual UUIDs
+  final String serviceUuid = "b64cfb1e-045c-4975-89d6-65949bcb35aa";
+  final String characteristicUuid = "33737322-fb5c-4a6f-a4d9-e41c1b20c30d";
+
+  Future<void> connect(BluetoothDevice device) async {
+    _device = device;
+    await device.connect(timeout: const Duration(seconds: 10));
+    _connected = true;
+    notifyListeners();
+
+    final services = await device.discoverServices();
+    final ecgChar = services
+        .expand((s) => s.characteristics)
+        .firstWhere((c) => c.uuid.toString() == characteristicUuid);
+
+    await ecgChar.setNotifyValue(true);
+
+    _subscription = ecgChar.onValueReceived.listen((data) {
+      final packet = EcgPacket.fromBytes(data);
+      if (packet != null) {
+        _ecgController.add(packet);
+      }
+    });
+  }
+
+  Future<void> disconnect() async {
+    await _subscription?.cancel();
+    _subscription = null;
+    await _device?.disconnect();
+    _device = null;
+    _connected = false;
+    notifyListeners();
+  }
+}

--- a/lib/views/widgets/ble_manager.dart
+++ b/lib/views/widgets/ble_manager.dart
@@ -4,24 +4,39 @@ import 'package:ecg_app/data/classes/ecg_packet.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 
+// Essentially a singleton that manages BLE connection to an ECG device.
+
+/*
+  - Connects / Disconnects from a single BLE ECG device
+  - Discovers the characteristic for ECG data and subscribes to notifications
+  - Parses bytes into EcgPacket objects
+  - Broadcats packets to listeners through ecgStream
+  - Expose connection status through ChangeNotifier
+*/
 class BleEcgManager extends ChangeNotifier {
+  // Singleton
   static final BleEcgManager _instance = BleEcgManager._internal();
   factory BleEcgManager() => _instance;
   BleEcgManager._internal();
 
   BluetoothDevice? _device;
+
+  // Subscription to characteristic value notifications
   StreamSubscription<List<int>>? _subscription;
 
+  // Broadcast stream of ECG packets for widgets like EcgChart to subscribe to
   final _ecgController = StreamController<EcgPacket>.broadcast();
   Stream<EcgPacket> get ecgStream => _ecgController.stream;
 
   bool _connected = false;
   bool get isConnected => _connected;
 
-  // replace with your actual UUIDs
+  // UUIDs of the ECG service and characteristic defined in the ESP32 code.
   final String serviceUuid = "b64cfb1e-045c-4975-89d6-65949bcb35aa";
   final String characteristicUuid = "33737322-fb5c-4a6f-a4d9-e41c1b20c30d";
 
+  /// Connects to device, discovers the ECG characteristic,
+  /// and begins streaming notifications into the ecgStream
   Future<void> connect(BluetoothDevice device) async {
     _device = device;
     await device.connect(timeout: const Duration(seconds: 10));
@@ -35,6 +50,7 @@ class BleEcgManager extends ChangeNotifier {
 
     await ecgChar.setNotifyValue(true);
 
+    // Our Listener that decodes bytes and transforms it into EcgPackets
     _subscription = ecgChar.onValueReceived.listen((data) {
       final packet = EcgPacket.fromBytes(data);
       if (packet != null) {
@@ -43,6 +59,8 @@ class BleEcgManager extends ChangeNotifier {
     });
   }
 
+  // Necessary for system to be idempotent
+  // Disconnects from the device, cancels notifs, and resets connection bool.
   Future<void> disconnect() async {
     await _subscription?.cancel();
     _subscription = null;


### PR DESCRIPTION
Holy moly this update is beautiful. Lets just jump into it
## Features
- Added `BleEcgManager` that streams data directly from the ESP32. It also
   - Manages connection/disconnection, maintains only 1 instance (singleton), and outputs a stream of `EcgPacket` for `ecg_chart.dart` to subscribe to
   - Essentially decoupled the chart in `ecg_chart.dart` from the actual FlutterBluePlus calls for BLE
   - If I have time to implement a BPM stream there doesn't need to be any duplication of BLE logic across another widget
- Let `EcgPacket` have its own class in `lib/data/classes/ecg_packet.dart` to both make it easy to find in case of modification of bluetooth data from the ESP32, and to make it easy to import in new widgets.

## Bug Fixes
- Fixed bug of data initially looking bad/jittery due to data scaling. 
- Fixed crashing when being in the charting page, switching to another page, and switching back to the charting page.