### PR TITLE
[Feature + Refactor] Add bpm charting and cleaned sessions & hsitorical.chart files

### DIFF
--- a/lib/views/pages/sessions.dart
+++ b/lib/views/pages/sessions.dart
@@ -15,7 +15,9 @@ class _SessionsState extends State<Sessions> {
   final client = Supabase.instance.client;
 
   List<Map<String, dynamic>> supabaseSessions = [];
+  // The ecg_session row we pull from supabase.
   Map<String, dynamic>? selectedSession;
+  // The ecg_data rows we pull from supabase.
   List<Map<String, dynamic>>? ecgData;
 
   bool isLoadingSessions = false;
@@ -43,7 +45,7 @@ class _SessionsState extends State<Sessions> {
     });
   }
 
-  /// Assigns returned rows from Supabase to flutter variables & sets
+  /// Assigns returned rows from Supabase to flutter variables
   Future<void> _loadSession(
     Map<String, dynamic> session, {
     bool chartBPM = false,
@@ -66,7 +68,7 @@ class _SessionsState extends State<Sessions> {
   Future<List<Map<String, dynamic>>> _fetchAllEcgRowsFromSession(
     String sessionId,
   ) async {
-    const pageSize = 1000;
+    const int pageSize = 1000;
     int from = 0;
     int to = pageSize - 1;
     final allRows = <Map<String, dynamic>>[];

--- a/lib/views/pages/sessions.dart
+++ b/lib/views/pages/sessions.dart
@@ -19,7 +19,7 @@ class _SessionsState extends State<Sessions> {
   Map<String, dynamic>? selectedSession;
   // Rows of ecg_data from supabase, all from the same session_id
   List<Map<String, dynamic>>? ecgData;
-
+  bool isChartingBPM = false;
   String? loadingSessionId;
   @override
   void initState() {
@@ -103,7 +103,11 @@ class _SessionsState extends State<Sessions> {
           title: Text("Session $formattedTime"),
           leading: BackButton(onPressed: clearSelection),
         ),
-        body: HistoricalChart(ecgRows: ecgData!, startTime: startTime),
+        body: HistoricalChart(
+          ecgRows: ecgData!,
+          startTime: startTime,
+          isChartingBPM: isChartingBPM,
+        ),
       );
     }
 
@@ -156,9 +160,16 @@ class _SessionsState extends State<Sessions> {
       children: [
         InkWell(
           onTap: () async {
-            setState(() => loadingSessionId = sessionId);
+            setState(() {
+              loadingSessionId = result['id'];
+              isChartingBPM = false; // <-- add this
+            });
+
             await selectSession(result);
-            setState(() => loadingSessionId = null);
+
+            setState(() {
+              loadingSessionId = null;
+            });
           },
           child: Container(
             padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
@@ -193,7 +204,32 @@ class _SessionsState extends State<Sessions> {
                     ],
                   ),
                 ),
-                const Icon(Icons.insert_chart),
+                IconButton(
+                  icon: const Icon(Icons.show_chart), // ECG icon
+                  onPressed: () async {
+                    setState(() => loadingSessionId = sessionId);
+                    await selectSession(result);
+
+                    setState(() {
+                      loadingSessionId = null;
+                    });
+                  },
+                ),
+                IconButton(
+                  icon: const Icon(Icons.favorite), // BPM icon
+                  onPressed: () async {
+                    setState(() {
+                      loadingSessionId = sessionId;
+                      isChartingBPM = true; // <-- true if this is your BPM view
+                    });
+
+                    await selectSession(result);
+
+                    setState(() {
+                      loadingSessionId = null;
+                    });
+                  },
+                ),
               ],
             ),
           ),

--- a/lib/views/widgets/historical_chart.dart
+++ b/lib/views/widgets/historical_chart.dart
@@ -35,6 +35,7 @@ class _HistoricalChartState extends State<HistoricalChart> {
   bool isProgrammaticSelection = false;
   double yAxisBound = 0;
 
+  // Time between samples from ESP32
   static const double sampleSpacing = 4.0;
   @override
   void initState() {


### PR DESCRIPTION
## BPM is now chartable
Previously the only time you were able to see BPM was during the real-time recording session. I figured it'd be cool to add the ability to view how the BPM changed over an ECG session.

Changelist:
- Modified `sessions.dart` to use `isChartingBPM` a bool that allows historical_chart.dart to reuse the same widget but populate its chart differently.
- Refactored `historical_chart.dart`'s constructor to take in a `bool isChartingBPM` to discern how to create its own chart. And thus created logic for when its true and false. Those being `_buildEcgPoints` and `_buildBpmPoints` respectively.
- Refactored both files by reducing duplicated logic, changing variable names for clarity, and utilizing more variables to avoid hard-coded values. 