### PR TITLE
[Feature] Add onboarding page

### DIFF
--- a/lib/data/classes/constants.dart
+++ b/lib/data/classes/constants.dart
@@ -1,3 +1,6 @@
 class KConstants {
   static const String brightnessKey = 'brightnessKey';
 }
+
+// Global variable for the user's name
+String firstName = '';

--- a/lib/views/pages/home.dart
+++ b/lib/views/pages/home.dart
@@ -1,3 +1,5 @@
+import 'package:ecg_app/data/classes/constants.dart';
+import 'package:ecg_app/views/pages/introduction_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:ecg_app/utils/greeting.dart';
 import 'package:ecg_app/views/widgets/sessions_widget.dart';
@@ -27,7 +29,7 @@ class _HomePageState extends State<HomePage> {
             // Greeting
             Center(
               child: Text(
-                greetOnTimeOfDay(),
+                "${greetOnTimeOfDay()} $firstName",
                 style: const TextStyle(
                   fontSize: 24,
                   fontWeight: FontWeight.bold,
@@ -97,7 +99,21 @@ class _HomePageState extends State<HomePage> {
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(16),
                             ),
-                            child: const Center(child: Text('Bottom Left')),
+                            child: Center(
+                              child: TextButton(
+                                onPressed: () => Navigator.pushReplacement(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) {
+                                      return const IntroductionScreens();
+                                    },
+                                  ),
+                                ),
+                                child: Text(
+                                  "Tap me to view the instructions again?",
+                                ),
+                              ),
+                            ),
                           ),
                         ),
                         const SizedBox(width: 16),

--- a/lib/views/pages/introduction_screen.dart
+++ b/lib/views/pages/introduction_screen.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:introduction_screen/introduction_screen.dart';
+
+class IntroductionScreens extends StatelessWidget {
+  const IntroductionScreens({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: IntroductionScreen(
+        pages: [
+          PageViewModel(
+            title: 'Welcome to empowering your health',
+            body:
+                'This is the home page. It gives you an overview of devices, recent sessions, and contact. You can always tap (fill this) to view this guide again.',
+            image: buildImage("images/image_1.png"),
+            //getPageDecoration, a method to customise the page style
+            decoration: getPageDecoration(),
+          ),
+          PageViewModel(
+            title: 'Bluetooth page',
+            body:
+                'Here is where you can find and connect to your health devices like an ECG. Select the device you want and tap on it to attempt to connect.',
+            image: buildImage("images/image_2.png"),
+            //getPageDecoration, a method to customise the page style
+            decoration: getPageDecoration(),
+          ),
+          PageViewModel(
+            title: 'Real time charting',
+            body:
+                'Once you connect to the device, we will chart the data in real time as we receive it. Do not worry - all the data is being saved so have no fear.',
+            image: buildImage("images/image_3.png"),
+            //getPageDecoration, a method to customise the page style
+            decoration: getPageDecoration(),
+          ),
+          PageViewModel(
+            title: 'View previous charts',
+            body:
+                "After a session is completed, you can view your session's chart anytime via the sessions page.",
+            image: buildImage("images/image_3.png"),
+            //getPageDecoration, a method to customise the page style
+            decoration: getPageDecoration(),
+          ),
+        ],
+        onDone: () {
+          if (kDebugMode) {
+            print("Done clicked");
+          }
+        },
+        //ClampingScrollPhysics prevent the scroll offset from exceeding the bounds of the content.
+        scrollPhysics: const ClampingScrollPhysics(),
+        showDoneButton: true,
+        showNextButton: true,
+        showSkipButton: true,
+        skip: const Text("Skip", style: TextStyle(fontWeight: FontWeight.w600)),
+        next: const Icon(Icons.forward),
+        done: const Text("Done", style: TextStyle(fontWeight: FontWeight.w600)),
+        dotsDecorator: getDotsDecorator(),
+      ),
+    );
+  }
+
+  //widget to add the image on screen
+  Widget buildImage(String imagePath) {
+    return Center(child: Image.asset(imagePath, width: 450, height: 200));
+  }
+
+  //method to customise the page style
+  PageDecoration getPageDecoration() {
+    return const PageDecoration(
+      imagePadding: EdgeInsets.only(top: 120),
+      pageColor: Colors.white,
+      bodyPadding: EdgeInsets.only(top: 8, left: 20, right: 20),
+      titlePadding: EdgeInsets.only(top: 50),
+      bodyTextStyle: TextStyle(color: Colors.black54, fontSize: 15),
+    );
+  }
+
+  //method to customize the dots style
+  DotsDecorator getDotsDecorator() {
+    return const DotsDecorator(
+      spacing: EdgeInsets.symmetric(horizontal: 2),
+      activeColor: Colors.indigo,
+      color: Colors.grey,
+      activeSize: Size(12, 5),
+      activeShape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.all(Radius.circular(25.0)),
+      ),
+    );
+  }
+}

--- a/lib/views/pages/introduction_screen.dart
+++ b/lib/views/pages/introduction_screen.dart
@@ -1,3 +1,4 @@
+import 'package:ecg_app/views/widgets/widget_tree.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:introduction_screen/introduction_screen.dart';
@@ -12,10 +13,10 @@ class IntroductionScreens extends StatelessWidget {
       body: IntroductionScreen(
         pages: [
           PageViewModel(
-            title: 'Welcome to empowering your health',
+            title: 'Welcome to the start of empowering your health.',
             body:
                 'This is the home page. It gives you an overview of devices, recent sessions, and contact. You can always tap (fill this) to view this guide again.',
-            image: buildImage("images/image_1.png"),
+            image: buildImage("images/ADD_IMAGE_LATER.png"),
             //getPageDecoration, a method to customise the page style
             decoration: getPageDecoration(),
           ),
@@ -23,30 +24,35 @@ class IntroductionScreens extends StatelessWidget {
             title: 'Bluetooth page',
             body:
                 'Here is where you can find and connect to your health devices like an ECG. Select the device you want and tap on it to attempt to connect.',
-            image: buildImage("images/image_2.png"),
-            //getPageDecoration, a method to customise the page style
+            image: buildImage("images/ADD_IMAGE_LATER.png"),
             decoration: getPageDecoration(),
           ),
           PageViewModel(
             title: 'Real time charting',
             body:
-                'Once you connect to the device, we will chart the data in real time as we receive it. Do not worry - all the data is being saved so have no fear.',
-            image: buildImage("images/image_3.png"),
-            //getPageDecoration, a method to customise the page style
+                'Once you connect to the device, we will chart the data in real time as we receive it. Do not worry - all the data is being saved so you can view it again.',
+            image: buildImage("images/ADD_IMAGE_LATER.png"),
             decoration: getPageDecoration(),
           ),
           PageViewModel(
             title: 'View previous charts',
             body:
                 "After a session is completed, you can view your session's chart anytime via the sessions page.",
-            image: buildImage("images/image_3.png"),
-            //getPageDecoration, a method to customise the page style
+            image: buildImage("images/ADD_IMAGE_LATER.png"),
             decoration: getPageDecoration(),
           ),
         ],
         onDone: () {
           if (kDebugMode) {
             print("Done clicked");
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(
+                builder: (context) {
+                  return WidgetTree();
+                },
+              ),
+            );
           }
         },
         //ClampingScrollPhysics prevent the scroll offset from exceeding the bounds of the content.

--- a/lib/views/pages/sign_in.dart
+++ b/lib/views/pages/sign_in.dart
@@ -1,5 +1,5 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:ecg_app/utils/dialog_alert.dart';
-import 'package:ecg_app/views/pages/introduction_screen.dart';
 import 'package:ecg_app/views/pages/sign_up.dart';
 import 'package:ecg_app/views/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
@@ -125,22 +125,6 @@ class _LogInPageState extends State<LogInPage> {
                   child: Text("Don't have an account? Try signing up"),
                 ),
               ),
-              Center(
-                child: FilledButton(
-                  onPressed: () {
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) {
-                          return IntroductionScreens();
-                        },
-                      ),
-                    );
-                  },
-
-                  child: Text("Onboard"),
-                ),
-              ),
             ],
           ),
         ),
@@ -159,6 +143,16 @@ class _LogInPageState extends State<LogInPage> {
 
       if (res.user != null) {
         print("Logged in");
+        final response = await supabase
+            .from('profiles')
+            .select('first_name')
+            .eq(
+              'id',
+              res.user!.id,
+            ) // if you need to filter for the current user
+            .single();
+
+        firstName = response['first_name'] as String;
         return res.user;
       } else {
         return null;

--- a/lib/views/pages/sign_in.dart
+++ b/lib/views/pages/sign_in.dart
@@ -1,4 +1,5 @@
 import 'package:ecg_app/utils/dialog_alert.dart';
+import 'package:ecg_app/views/pages/introduction_screen.dart';
 import 'package:ecg_app/views/pages/sign_up.dart';
 import 'package:ecg_app/views/widgets/widget_tree.dart';
 import 'package:flutter/material.dart';
@@ -122,6 +123,22 @@ class _LogInPageState extends State<LogInPage> {
                   },
 
                   child: Text("Don't have an account? Try signing up"),
+                ),
+              ),
+              Center(
+                child: FilledButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) {
+                          return IntroductionScreens();
+                        },
+                      ),
+                    );
+                  },
+
+                  child: Text("Onboard"),
                 ),
               ),
             ],

--- a/lib/views/pages/sign_up.dart
+++ b/lib/views/pages/sign_up.dart
@@ -1,5 +1,6 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:ecg_app/utils/dialog_alert.dart';
-import 'package:ecg_app/views/widgets/widget_tree.dart';
+import 'package:ecg_app/views/pages/introduction_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -145,11 +146,12 @@ class _SignUpPageState extends State<SignUpPage> {
                     newUser = await signUp();
 
                     if (newUser != null) {
+                      firstName = firstNameController.text;
                       Navigator.pushReplacement(
                         context,
                         MaterialPageRoute(
                           builder: (context) {
-                            return WidgetTree();
+                            return const IntroductionScreens();
                           },
                         ),
                       );
@@ -187,7 +189,7 @@ class _SignUpPageState extends State<SignUpPage> {
         print("Signed up");
         print(res.toString());
       }
-      final insertUser = await supabase
+      await supabase
           .from('profiles')
           .insert({
             'id': res.user?.id,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  dots_indicator:
+    dependency: transitive
+    description:
+      name: dots_indicator
+      sha256: c070af5058a084ba7b354df4b4c26c719595d70a3531eea6edd8af8716684ba3
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -198,6 +206,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
+  flutter_keyboard_visibility_linux:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_linux
+      sha256: "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_keyboard_visibility_macos:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_macos
+      sha256: c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  flutter_keyboard_visibility_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_platform_interface
+      sha256: e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
+  flutter_keyboard_visibility_temp_fork:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_temp_fork
+      sha256: e3d02900640fbc1129245540db16944a0898b8be81694f4bf04b6c985bed9048
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.5"
+  flutter_keyboard_visibility_windows:
+    dependency: transitive
+    description:
+      name: flutter_keyboard_visibility_windows
+      sha256: fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -264,6 +312,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.20.2"
+  introduction_screen:
+    dependency: "direct main"
+    description:
+      name: introduction_screen
+      sha256: "47ad51281f86c3ed47e0c1a0008899ad253ca71e8b626fd862e55993825a271b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   jwt_decode:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   supabase_flutter: ^2.10.0
   lottie: ^3.3.1
   intl: ^0.20.2
+  introduction_screen: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## On boarding / explanation  page is here!
- Added the user's first name in home when used with greeting
- Added `introduction_screen` to pubspec.yaml to leverage the package to build the introduction page
- Created `introduction_screens.dart` that uses the introduction_screens package to build an on boarding swipe-able tutorial of the project 
- Added a query in `sign_in.dart` to retrieve the user's first name for the greeting (new table)
- Modified `sign_up.dart` to route the user to the on boarding pages.
- Added a button that routes the user to the on boarding page to review the information on the home page