### PR TITLE
[Refactor + Feature] Utilize more constants and add text scailing 

### DIFF
--- a/lib/data/classes/constants.dart
+++ b/lib/data/classes/constants.dart
@@ -45,7 +45,11 @@ class KEcgConstants {
 
 /// Text / font sizes
 class KTextSize {
-  static const double body = 14.0;
-  static const double title = 18.0;
-  static const double headline = 24.0;
+  static const double xs = 14.0;
+  static const double sm = 16.0;
+  static const double md = 18.0;
+  static const double lg = 24.0;
+  static const double xl = 30.0;
+  static const double xxl = 38.0;
+  static const double xxxl = 40.0;
 }

--- a/lib/data/classes/constants.dart
+++ b/lib/data/classes/constants.dart
@@ -4,3 +4,48 @@ class KConstants {
 
 // Global variable for the user's name
 String firstName = '';
+
+/// Database table names
+/// Database table names
+class KTables {
+  static const ecgSession = 'ecg_session';
+  static const userProfile = 'profiles';
+  static const ecgData = 'ecg_data';
+}
+
+/// Columns for `profiles` table
+class KProfileColumns {
+  static const id = 'id';
+  static const firstName = 'first_name';
+  static const lastName = 'last_name';
+  static const signUpReason = 'signup_reason';
+}
+
+/// Columns for `ecg_session` table
+class KSessionColumns {
+  static const id = 'id';
+  static const userId = 'user_id';
+  static const startTime = 'start_time';
+  static const endTime = 'end_time';
+}
+
+/// Columns for `ecg_data` table
+class KECGDataColumns {
+  static const id = 'id';
+  static const sessionId = 'session_id';
+  static const ecgData = 'ecg_data';
+  static const timestamp = 'timestamp_ms';
+  static const bpm = 'bpm';
+}
+
+class KEcgConstants {
+  static const double sampleSpacingMs = 4.0;
+  static const int packetSize = 28;
+}
+
+/// Text / font sizes
+class KTextSize {
+  static const double body = 14.0;
+  static const double title = 18.0;
+  static const double headline = 24.0;
+}

--- a/lib/data/classes/ecg_packet.dart
+++ b/lib/data/classes/ecg_packet.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
+import 'package:ecg_app/data/classes/constants.dart';
+
 class EcgPacket {
   // Currently is 24 bytes - 10 samples of 2 byte length
   // and a 4 byte timestamp.
@@ -10,7 +12,7 @@ class EcgPacket {
   EcgPacket(this.samples, this.timestamp, this.bpm);
 
   static EcgPacket? fromBytes(List<int> value) {
-    if (value.length != 28) {
+    if (value.length != KEcgConstants.packetSize) {
       print("Unexpected packet size: ${value.length}");
       return null;
     }

--- a/lib/data/classes/notifiers.dart
+++ b/lib/data/classes/notifiers.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 ValueNotifier<bool> isDarkModeNotifier = ValueNotifier(true);
 ValueNotifier<int> selectedPageNotifier = ValueNotifier(0);
 ValueNotifier<DeviceWrapper?> connectedDevice = ValueNotifier(null);
 ValueNotifier<int> bpm = ValueNotifier(0);
+ValueNotifier<double> textSize = ValueNotifier(1.0);
 
 class DeviceWrapper {
   final BluetoothDevice device;
@@ -19,4 +21,14 @@ class DeviceWrapper {
 
   @override
   int get hashCode => device.remoteId.hashCode;
+}
+
+Future<void> loadTextSize() async {
+  final prefs = await SharedPreferences.getInstance();
+  textSize.value = prefs.getDouble('textSize') ?? 1.0;
+}
+
+Future<void> saveTextSize(double value) async {
+  final prefs = await SharedPreferences.getInstance();
+  await prefs.setDouble('textSize', value);
 }

--- a/lib/views/pages/ble_scanner.dart
+++ b/lib/views/pages/ble_scanner.dart
@@ -261,7 +261,7 @@ class _BleScannerState extends State<BleScanner> {
                 ],
               ),
             ),
-            const Icon(Icons.bluetooth),
+            const Icon(Icons.bluetooth, color: Colors.lightBlue),
           ],
         ),
       ),

--- a/lib/views/pages/home.dart
+++ b/lib/views/pages/home.dart
@@ -64,7 +64,7 @@ class _HomePageState extends State<HomePage> {
                                     child: Text(
                                       'Recent Sessions',
                                       style: TextStyle(
-                                        fontSize: 16,
+                                        fontSize: 24,
                                         fontWeight: FontWeight.bold,
                                       ),
                                     ),
@@ -91,7 +91,7 @@ class _HomePageState extends State<HomePage> {
                                     child: Text(
                                       'Recent Devices',
                                       style: TextStyle(
-                                        fontSize: 16,
+                                        fontSize: 24,
                                         fontWeight: FontWeight.bold,
                                       ),
                                     ),

--- a/lib/views/pages/home.dart
+++ b/lib/views/pages/home.dart
@@ -8,13 +8,7 @@ import 'package:ecg_app/utils/greeting.dart';
 import 'package:ecg_app/views/widgets/sessions_widget.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({
-    super.key,
-    required this.appBarTitle,
-    required this.appBarColor,
-  });
-  final String appBarTitle;
-  final Color appBarColor;
+  const HomePage({super.key});
 
   @override
   State<HomePage> createState() => _HomePageState();
@@ -32,7 +26,7 @@ class _HomePageState extends State<HomePage> {
             // Greeting
             Center(
               child: ScaledText(
-                '"${greetOnTimeOfDay()} $firstName"',
+                '${greetOnTimeOfDay()} $firstName',
                 baseSize: KTextSize.xl,
                 style: const TextStyle(fontWeight: FontWeight.bold),
               ),
@@ -60,10 +54,10 @@ class _HomePageState extends State<HomePage> {
                                 crossAxisAlignment: CrossAxisAlignment.stretch,
                                 children: [
                                   const Center(
-                                    child: Text(
+                                    child: ScaledText(
                                       'Recent Sessions',
+                                      baseSize: KTextSize.lg,
                                       style: TextStyle(
-                                        fontSize: 24,
                                         fontWeight: FontWeight.bold,
                                       ),
                                     ),
@@ -87,8 +81,9 @@ class _HomePageState extends State<HomePage> {
                                 crossAxisAlignment: CrossAxisAlignment.stretch,
                                 children: [
                                   Center(
-                                    child: Text(
+                                    child: ScaledText(
                                       'Recent Devices',
+                                      baseSize: KTextSize.lg,
                                       style: TextStyle(
                                         fontSize: 24,
                                         fontWeight: FontWeight.bold,

--- a/lib/views/pages/home.dart
+++ b/lib/views/pages/home.dart
@@ -2,6 +2,7 @@ import 'package:ecg_app/data/classes/constants.dart';
 import 'package:ecg_app/views/pages/about_app.dart';
 import 'package:ecg_app/views/pages/introduction_screen.dart';
 import 'package:ecg_app/views/widgets/ble_recent.dart';
+import 'package:ecg_app/views/widgets/scaled_text.dart';
 import 'package:flutter/material.dart';
 import 'package:ecg_app/utils/greeting.dart';
 import 'package:ecg_app/views/widgets/sessions_widget.dart';
@@ -30,12 +31,10 @@ class _HomePageState extends State<HomePage> {
           children: [
             // Greeting
             Center(
-              child: Text(
-                "${greetOnTimeOfDay()} $firstName",
-                style: const TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                ),
+              child: ScaledText(
+                '"${greetOnTimeOfDay()} $firstName"',
+                baseSize: KTextSize.xl,
+                style: const TextStyle(fontWeight: FontWeight.bold),
               ),
             ),
             const SizedBox(height: 16),

--- a/lib/views/pages/sessions.dart
+++ b/lib/views/pages/sessions.dart
@@ -1,3 +1,4 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -24,9 +25,9 @@ class _SessionsState extends State<Sessions> {
   /// Returns all sessions from Supabase that the user owns.
   Future<void> fetchSessionsNoLimit() async {
     final data = await supabase
-        .from('ecg_session')
+        .from(KTables.ecgSession)
         .select('*')
-        .order('start_time', ascending: false);
+        .order(KSessionColumns.startTime, ascending: false);
 
     setState(() {
       supabaseSessions = List<Map<String, dynamic>>.from(data);

--- a/lib/views/pages/sessions.dart
+++ b/lib/views/pages/sessions.dart
@@ -1,4 +1,5 @@
 import 'package:ecg_app/data/classes/constants.dart';
+import 'package:ecg_app/views/widgets/scaled_text.dart';
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -42,14 +43,25 @@ class _SessionsState extends State<Sessions> {
         title: Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            const Text('Sessions'),
+            ScaledText(
+              'Sessions',
+              baseSize: KTextSize.xxl,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+
             const SizedBox(width: 8),
             // Animate the session count
             TweenAnimationBuilder<int>(
               tween: IntTween(begin: 0, end: supabaseSessions.length),
               duration: const Duration(milliseconds: 800),
               builder: (context, value, _) {
-                return Text('($value)', style: const TextStyle(fontSize: 16));
+                return Text(
+                  '($value)',
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                );
               },
             ),
           ],

--- a/lib/views/pages/settings_page.dart
+++ b/lib/views/pages/settings_page.dart
@@ -1,0 +1,86 @@
+import 'package:ecg_app/data/classes/notifiers.dart';
+import 'package:ecg_app/views/widgets/scaled_text.dart';
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatefulWidget {
+  const SettingsPage({super.key, required this.title});
+  final String title;
+
+  @override
+  State<SettingsPage> createState() => _SettingsPageState();
+}
+
+class _SettingsPageState extends State<SettingsPage> {
+  double sliderVal = 0.0;
+
+  String _sizeLabel(double value) {
+    switch (value.toInt()) {
+      case 1:
+        return "Smaller";
+      case 2:
+        return "Larger";
+      case 0:
+      default:
+        return "Default";
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    sliderVal = textSize.value;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title)),
+      body: ValueListenableBuilder<double>(
+        valueListenable: textSize,
+        builder: (context, value, child) {
+          return SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                children: [
+                  SizedBox(
+                    height: 25,
+                    child: ScaledText(
+                      "Adjust font size?",
+                      baseSize: 16,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  SizedBox(
+                    height: 25,
+                    child: ScaledText(
+                      "Current: ${_sizeLabel(sliderVal)}",
+                      baseSize: 16,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                  const Divider(height: 20),
+                  Slider.adaptive(
+                    max: 2,
+                    divisions: 2,
+                    value: sliderVal,
+                    label: _sizeLabel(sliderVal),
+                    onChanged: (double value) {
+                      setState(() {
+                        sliderVal = value;
+                        textSize.value = sliderVal;
+                        saveTextSize(sliderVal);
+                      });
+                    },
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/views/pages/sign_in.dart
+++ b/lib/views/pages/sign_in.dart
@@ -144,15 +144,15 @@ class _LogInPageState extends State<LogInPage> {
       if (res.user != null) {
         print("Logged in");
         final response = await supabase
-            .from('profiles')
-            .select('first_name')
+            .from(KTables.userProfile)
+            .select(KProfileColumns.firstName)
             .eq(
               'id',
               res.user!.id,
             ) // if you need to filter for the current user
             .single();
 
-        firstName = response['first_name'] as String;
+        firstName = response[KProfileColumns.firstName] as String;
         return res.user;
       } else {
         return null;

--- a/lib/views/pages/sign_up.dart
+++ b/lib/views/pages/sign_up.dart
@@ -190,12 +190,12 @@ class _SignUpPageState extends State<SignUpPage> {
         print(res.toString());
       }
       await supabase
-          .from('profiles')
+          .from(KTables.userProfile)
           .insert({
-            'id': res.user?.id,
-            "first_name": firstNameController.text,
-            "last_name": lastNameController.text,
-            "signup_reason": dropdownValue,
+            KProfileColumns.id: res.user?.id,
+            KProfileColumns.firstName: firstNameController.text,
+            KProfileColumns.lastName: lastNameController.text,
+            KProfileColumns.signUpReason: dropdownValue,
           })
           .select()
           .single();

--- a/lib/views/widgets/ble_recent.dart
+++ b/lib/views/widgets/ble_recent.dart
@@ -1,4 +1,5 @@
 import 'package:ecg_app/utils/ble_manager.dart';
+import 'package:ecg_app/views/widgets/scaled_text.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
@@ -50,7 +51,7 @@ class _RecentDevicesTileState extends State<RecentDevicesTile> {
     return ListView.builder(
       itemCount: _devices.length,
       itemBuilder: (context, index) {
-        final d = _devices[index];
+        final currentDevice = _devices[index];
 
         return Card(
           elevation: 3,
@@ -59,7 +60,7 @@ class _RecentDevicesTileState extends State<RecentDevicesTile> {
           ),
           child: InkWell(
             borderRadius: BorderRadius.circular(16),
-            onTap: () => _connectTo(d['id']!),
+            onTap: () => _connectTo(currentDevice['id']!),
             child: Padding(
               padding: const EdgeInsets.all(16),
               child: Row(
@@ -71,18 +72,18 @@ class _RecentDevicesTileState extends State<RecentDevicesTile> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
-                          d['name'] ?? 'Unknown',
-                          style: const TextStyle(
-                            fontSize: 16,
-                            fontWeight: FontWeight.bold,
-                          ),
+                        ScaledText(
+                          currentDevice['name'] ?? 'Unknown',
+                          baseSize: 16,
+                          style: const TextStyle(fontWeight: FontWeight.bold),
                         ),
+
                         const SizedBox(height: 4),
-                        Text(
-                          d['id'] ?? '',
+                        ScaledText(
+                          currentDevice['id'] ?? '',
+                          baseSize: 14,
                           style: const TextStyle(
-                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
                             color: Colors.grey,
                           ),
                         ),
@@ -94,7 +95,7 @@ class _RecentDevicesTileState extends State<RecentDevicesTile> {
                       Icons.bluetooth_connected,
                       color: Colors.lightBlue,
                     ),
-                    onPressed: () => _connectTo(d['id']!),
+                    onPressed: () => _connectTo(currentDevice['id']!),
                   ),
                 ],
               ),

--- a/lib/views/widgets/historical_chart.dart
+++ b/lib/views/widgets/historical_chart.dart
@@ -1,3 +1,4 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:ecg_app/views/pages/ecg_chart.dart';
 import 'package:flutter/material.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
@@ -34,7 +35,7 @@ class _HistoricalChartState extends State<HistoricalChart> {
   double yAxisBound = 0;
 
   // Time between samples from ESP32
-  static const double sampleSpacing = 4.0;
+  static const double sampleSpacing = KEcgConstants.sampleSpacingMs;
   @override
   void initState() {
     super.initState();
@@ -53,8 +54,9 @@ class _HistoricalChartState extends State<HistoricalChart> {
     final dataPoints = <EcgDataPoint>[];
     final startMs = widget.startTime.millisecondsSinceEpoch.toDouble();
     for (var row in widget.ecgRows) {
-      final timestampMs = (row['timestamp_ms'] as int).toDouble() + startMs;
-      final samples = List<int>.from(row['ecg_data']);
+      final timestampMs =
+          (row[KECGDataColumns.timestamp] as int).toDouble() + startMs;
+      final samples = List<int>.from(row[KTables.ecgData]);
       for (int i = 0; i < samples.length; i++) {
         dataPoints.add(
           EcgDataPoint(timestampMs + i * sampleSpacing, samples[i].toDouble()),
@@ -69,8 +71,9 @@ class _HistoricalChartState extends State<HistoricalChart> {
   List<EcgDataPoint> _buildBpmPoints() {
     final startMs = widget.startTime.millisecondsSinceEpoch.toDouble();
     return widget.ecgRows.map((row) {
-      final timestampMs = (row['timestamp_ms'] as int).toDouble() + startMs;
-      return EcgDataPoint(timestampMs, (row['bpm']).toDouble());
+      final timestampMs =
+          (row[KECGDataColumns.timestamp] as int).toDouble() + startMs;
+      return EcgDataPoint(timestampMs, (row[KECGDataColumns.bpm]).toDouble());
     }).toList();
   }
 

--- a/lib/views/widgets/scaled_text.dart
+++ b/lib/views/widgets/scaled_text.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:ecg_app/data/classes/notifiers.dart';
+
+class ScaledText extends StatelessWidget {
+  final String text;
+  final double baseSize;
+  final TextStyle? style;
+  final TextAlign? textAlign;
+  final int? maxLines;
+
+  const ScaledText(
+    this.text, {
+    super.key,
+    required this.baseSize,
+    this.style,
+    this.textAlign,
+    this.maxLines,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<double>(
+      valueListenable: textSize,
+      builder: (context, scale, _) {
+        double sizeFactor;
+        // smaller
+        if (scale == 1) {
+          sizeFactor = 0.8;
+        }
+        // larger
+        else if (scale == 2) {
+          sizeFactor = 1.2;
+        }
+        // default at 0
+        else {
+          sizeFactor = 1.0;
+        }
+
+        return Text(
+          text,
+          maxLines: maxLines,
+          textAlign: textAlign,
+          style: (style ?? const TextStyle()).copyWith(
+            fontSize: baseSize * sizeFactor,
+          ),
+          overflow: TextOverflow.ellipsis,
+        );
+      },
+    );
+  }
+}

--- a/lib/views/widgets/sessions_widget.dart
+++ b/lib/views/widgets/sessions_widget.dart
@@ -1,3 +1,4 @@
+import 'package:ecg_app/data/classes/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
@@ -30,9 +31,9 @@ class _SessionsTileState extends State<SessionsTile> {
     setState(() => isLoadingSessions = true);
 
     var query = client
-        .from('ecg_session')
+        .from(KTables.ecgSession)
         .select('*')
-        .order('start_time', ascending: false);
+        .order(KSessionColumns.startTime, ascending: false);
     if (limit != null) query = query.limit(limit);
 
     final data = await query;
@@ -63,9 +64,9 @@ class _SessionsTileState extends State<SessionsTile> {
     // the postgres database.
     while (true) {
       final chunk = await client
-          .from('ecg_data')
+          .from(KTables.ecgData)
           .select('*')
-          .eq('session_id', sessionId)
+          .eq(KECGDataColumns.sessionId, sessionId)
           .range(from, to);
 
       if (chunk.isEmpty) break;
@@ -126,7 +127,7 @@ class _SessionsTileState extends State<SessionsTile> {
 
   Widget _buildSessionTile(Map<String, dynamic> session, int index) {
     final startDate = DateTime.parse(session['start_time']).toLocal();
-    final endDate = DateTime.parse(session['end_time']).toLocal();
+    final endDate = DateTime.parse(session[KSessionColumns.endTime]).toLocal();
     final duration = endDate.difference(startDate);
     final startText = DateFormat('yyyy-MM-dd HH:mm').format(startDate);
     final endText = DateFormat('yyyy-MM-dd HH:mm').format(endDate);
@@ -157,19 +158,22 @@ class _SessionsTileState extends State<SessionsTile> {
                         Text(
                           "Session $index",
                           style: const TextStyle(
-                            fontSize: 16,
+                            fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
-                        const SizedBox(height: 4),
+                        const SizedBox(height: 2),
                         Text(
                           "Duration: ${duration.inMinutes}:${(duration.inSeconds % 60).toString().padLeft(2, '0')} $unitOfTime",
                           style: const TextStyle(
-                            fontSize: 14,
+                            fontSize: 16,
                             color: Colors.grey,
                           ),
                         ),
-                        Text('Start: $startText, End: $endText'),
+                        Text(
+                          'Start: $startText, End: $endText',
+                          style: const TextStyle(fontSize: 16),
+                        ),
                       ],
                     ),
                   ),

--- a/lib/views/widgets/sessions_widget.dart
+++ b/lib/views/widgets/sessions_widget.dart
@@ -1,4 +1,5 @@
 import 'package:ecg_app/data/classes/constants.dart';
+import 'package:ecg_app/views/widgets/scaled_text.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:lottie/lottie.dart';
@@ -94,11 +95,11 @@ class _SessionsTileState extends State<SessionsTile> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Flexible(
-                  child: Text(
+                  child: ScaledText(
                     'Session ${DateFormat('yyyy-MM-dd HH:mm:ss').format(startTime)}',
-                    overflow: TextOverflow.ellipsis,
+
+                    baseSize: 18,
                     style: const TextStyle(
-                      fontSize: 40,
                       fontWeight: FontWeight.bold,
                       color: Colors.black,
                     ),
@@ -155,24 +156,34 @@ class _SessionsTileState extends State<SessionsTile> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                        Text(
+                        ScaledText(
                           "Session $index",
+
+                          baseSize: 18,
                           style: const TextStyle(
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
                         ),
+
                         const SizedBox(height: 2),
-                        Text(
+                        ScaledText(
                           "Duration: ${duration.inMinutes}:${(duration.inSeconds % 60).toString().padLeft(2, '0')} $unitOfTime",
+                          baseSize: 18,
                           style: const TextStyle(
                             fontSize: 16,
+                            fontWeight: FontWeight.bold,
                             color: Colors.grey,
                           ),
                         ),
-                        Text(
+                        ScaledText(
                           'Start: $startText, End: $endText',
-                          style: const TextStyle(fontSize: 16),
+
+                          baseSize: 18,
+                          style: const TextStyle(
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
                         ),
                       ],
                     ),

--- a/lib/views/widgets/widget_tree.dart
+++ b/lib/views/widgets/widget_tree.dart
@@ -30,7 +30,7 @@ final List<PageConfig> navbarPages = [
   PageConfig(
     title: "Home page",
     color: const Color(0xFF086788),
-    page: HomePage(appBarTitle: "Home page", appBarColor: Color(0xFF086788)),
+    page: HomePage(),
     icon: Icons.home,
     label: "Home",
   ),

--- a/lib/views/widgets/widget_tree.dart
+++ b/lib/views/widgets/widget_tree.dart
@@ -3,6 +3,7 @@ import 'package:ecg_app/data/classes/notifiers.dart';
 import 'package:ecg_app/views/pages/ecg_page.dart';
 import 'package:ecg_app/views/pages/home.dart';
 import 'package:ecg_app/views/pages/sessions.dart';
+import 'package:ecg_app/views/pages/settings_page.dart';
 import 'package:ecg_app/views/widgets/navbar_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -76,16 +77,28 @@ class WidgetTree extends StatelessWidget {
           appBar: AppBar(
             title: Text(
               config.title,
-              style: TextStyle(
-                color: Colors.black,
+              style: const TextStyle(
+                fontSize: 38,
                 fontWeight: FontWeight.bold,
-                fontSize: 30.0,
+                color: Colors.black,
               ),
             ),
             backgroundColor: config.color,
             centerTitle: true,
             actions: [
-              IconButton(onPressed: () {}, icon: const Icon(Icons.settings)),
+              IconButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) {
+                        return SettingsPage(title: "Settings wow");
+                      },
+                    ),
+                  );
+                },
+                icon: const Icon(Icons.settings),
+              ),
               IconButton(
                 onPressed: () async {
                   final SharedPreferences prefs =


### PR DESCRIPTION
## This branch got a little out of scope but I was in the zone
- Created `scaled_text.dart` a widget that listens to a valuenotifier to adjust the size of specific Text objects
- Updated `constants.dart` to utilize more constants; such as database table names, database table columns, and variables that were redeclared in multiple files like 4.0 which is spacing between samples
- Updated `home.dart` to utilize the ScaledText widget.
- Added a `Settings.dart` page to the appbar to let the user jump and modify the text size, and preview the text size changes.

### Here is a sample. Notice how not every text object (like the cards underneath the recent ones) have not had their text adjusted. The ScaledText widget must be applied to text to allow it to be scaled. Also I didn't do them because I plan on changing their design <3
<img width="1910" height="1027" alt="image" src="https://github.com/user-attachments/assets/a057d4d6-4fe2-4413-9b52-77e4d9c08a1d" />
